### PR TITLE
Adjusted VerifyMime Endpoint

### DIFF
--- a/CopeID.API/Controllers/Documents/DocumentController.cs
+++ b/CopeID.API/Controllers/Documents/DocumentController.cs
@@ -1,9 +1,8 @@
-﻿using System.Net;
-
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 using CopeID.API.Services.Documents;
+using CopeID.API.ViewModels.Documents;
 using CopeID.Models.Documents;
 using CopeID.QueryModels.Documents;
 
@@ -16,11 +15,11 @@ namespace CopeID.API.Controllers.Documents
         public DocumentController(IDocumentService documentService) : base(documentService)
         { }
 
-        [HttpGet("VerifyMime/{mimeType}")]
+        [HttpPost("VerifyMime")]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public virtual IActionResult VerifyType(string mimeType)
+        public virtual IActionResult VerifyType([FromBody] DocumentMimeType model)
         {
-            return Ok(_entityService.IsValidMimeType(WebUtility.UrlDecode(mimeType)));
+            return Ok(_entityService.IsValidMimeType(model));
         }
     }
 }

--- a/CopeID.API/Controllers/Filters/FilterController.cs
+++ b/CopeID.API/Controllers/Filters/FilterController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 
 using CopeID.API.Services.Filters;
-using CopeID.API.ViewModels;
+using CopeID.API.ViewModels.Filters;
 using CopeID.Models.Filters;
 using CopeID.QueryModels.Filters;
 

--- a/CopeID.API/Services/Documents/IDocumentService.cs
+++ b/CopeID.API/Services/Documents/IDocumentService.cs
@@ -1,10 +1,11 @@
-﻿using CopeID.Models.Documents;
+﻿using CopeID.API.ViewModels.Documents;
+using CopeID.Models.Documents;
 using CopeID.QueryModels.Documents;
 
 namespace CopeID.API.Services.Documents
 {
     public interface IDocumentService : IBaseQueryableEntityService<Document, DocumentQueryModel>
     {
-        bool IsValidMimeType(string mimeType);
+        bool IsValidMimeType(DocumentMimeType model);
     }
 }

--- a/CopeID.API/Services/Filters/FilterService.cs
+++ b/CopeID.API/Services/Filters/FilterService.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 
 using CopeID.API.FilterModels;
-using CopeID.API.ViewModels;
+using CopeID.API.ViewModels.Filters;
 using CopeID.Context;
 using CopeID.Models;
 using CopeID.Models.Filters;

--- a/CopeID.API/Services/Filters/IFilterService.cs
+++ b/CopeID.API/Services/Filters/IFilterService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-using CopeID.API.ViewModels;
+using CopeID.API.ViewModels.Filters;
 using CopeID.Models.Filters;
 using CopeID.QueryModels.Filters;
 

--- a/CopeID.API/ViewModels/Documents/DocumentMimeType.cs
+++ b/CopeID.API/ViewModels/Documents/DocumentMimeType.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace CopeID.API.ViewModels.Documents
+{
+    public class DocumentMimeType
+    {
+        [Required]
+        public string MimeType { get; set; }
+
+        public DocumentMimeType(string mimeType)
+        {
+            MimeType = mimeType;
+        }
+    }
+}

--- a/CopeID.API/ViewModels/Filters/FilterOptionValueViewModel.cs
+++ b/CopeID.API/ViewModels/Filters/FilterOptionValueViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CopeID.API.ViewModels
+namespace CopeID.API.ViewModels.Filters
 {
     public class FilterOptionValueViewModel
     {

--- a/CopeID.API/ViewModels/Filters/FilterResultRequestViewModel.cs
+++ b/CopeID.API/ViewModels/Filters/FilterResultRequestViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CopeID.API.ViewModels
+namespace CopeID.API.ViewModels.Filters
 {
     public class FilterResultRequestViewModel
     {

--- a/CopeID.API/ViewModels/Filters/FilterResultViewModel.cs
+++ b/CopeID.API/ViewModels/Filters/FilterResultViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CopeID.API.ViewModels
+namespace CopeID.API.ViewModels.Filters
 {
     public class FilterResultViewModel
     {


### PR DESCRIPTION
Fixed bug where `/Document/VerifyMime` would fail on production application. Switched to use POST request and body data over a GET request.