### PR TITLE
Functionality for Data Pagination via API

### DIFF
--- a/CopeID.API/Controllers/BaseEntityController.cs
+++ b/CopeID.API/Controllers/BaseEntityController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 using CopeID.API.Services;
+using CopeID.API.ViewModels.Pagination;
 using CopeID.Core.Exceptions;
 using CopeID.Models;
 
@@ -24,8 +25,18 @@ namespace CopeID.API.Controllers
 
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public virtual async Task<IActionResult> Get()
+        public virtual async Task<IActionResult> Get([FromQuery] PaginationRequest paginationRequest)
         {
+            // If a pagination request was supplied, use pagination and limit the number of returned results.
+            if (paginationRequest.IsValid())
+            {
+                PaginationResponse<TEntity> paginationResponse = await _entityService.GetPaged(
+                    new PaginationRequest(paginationRequest.PageNumber, paginationRequest.PageSize)
+                );
+                return Ok(paginationResponse);
+            }
+
+            // Otherwise, return everything.
             List<TEntity> entities = await _entityService.GetAll();
             return Ok(entities);
         }

--- a/CopeID.API/Controllers/BaseEntityQueryableController.cs
+++ b/CopeID.API/Controllers/BaseEntityQueryableController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 using CopeID.API.Services;
+using CopeID.API.ViewModels.Pagination;
 using CopeID.Core.Exceptions;
 using CopeID.Models;
 using CopeID.QueryModels;
@@ -26,8 +27,19 @@ namespace CopeID.API.Controllers
 
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public virtual async Task<IActionResult> Get([FromQuery] TQueryModel queryModel)
+        public virtual async Task<IActionResult> Get([FromQuery] TQueryModel queryModel, [FromQuery] PaginationRequest paginationRequest)
         {
+            // If a pagination request was supplied, use pagination and limit the number of returned results.
+            if (paginationRequest.IsValid())
+            {
+                PaginationResponse<TEntity> paginationResponse = await _entityService.GetPaged(
+                    new PaginationRequest(paginationRequest.PageNumber, paginationRequest.PageSize),
+                    queryModel
+                );
+                return Ok(paginationResponse);
+            }
+
+            // Otherwise, return everything.
             List<TEntity> entities = await _entityService.GetAll(queryModel);
             return Ok(entities);
         }

--- a/CopeID.API/Services/BaseEntityService.cs
+++ b/CopeID.API/Services/BaseEntityService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;
 
+using CopeID.API.ViewModels.Pagination;
 using CopeID.Core.Exceptions;
 using CopeID.Context;
 using CopeID.Models;
@@ -25,6 +26,16 @@ namespace CopeID.API.Services
 
         public virtual async Task<List<TEntity>> GetAll() =>
             await _set.AsTracking().ToListAsync();
+
+        public virtual async Task<PaginationResponse<TEntity>> GetPaged(PaginationRequest paginationRequest)
+        {
+            IQueryable<TEntity> allResultsQuery = _set.AsTracking();
+            IQueryable<TEntity> pagedResultsQuery = allResultsQuery.Skip(paginationRequest.PageSize * (paginationRequest.PageNumber - 1)).Take(paginationRequest.PageSize);
+            return new PaginationResponse<TEntity>(
+                await allResultsQuery.CountAsync(),
+                await pagedResultsQuery.ToListAsync()
+            );
+        }
 
         public virtual async Task<TEntity> GetTrackedAsync(Guid id) =>
             await FindEntityAsync(id, _set.AsTracking());

--- a/CopeID.API/Services/BaseQueryableEntityService.cs
+++ b/CopeID.API/Services/BaseQueryableEntityService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;
 
+using CopeID.API.ViewModels.Pagination;
 using CopeID.Context;
 using CopeID.Models;
 using CopeID.QueryModels;
@@ -20,6 +21,16 @@ namespace CopeID.API.Services
 
         public virtual async Task<List<TEntity>> GetAll(TQueryModel queryModel) =>
             await (queryModel != null ? queryModel.FilterQuery(_set.AsTracking()) : _set.AsTracking()).ToListAsync();
+
+        public virtual async Task<PaginationResponse<TEntity>> GetPaged(PaginationRequest paginationRequest, TQueryModel queryModel)
+        {
+            IQueryable<TEntity> allResultsQuery = queryModel != null ? queryModel.FilterQuery(_set.AsTracking()) : _set.AsTracking();
+            IQueryable<TEntity> pagedResultsQuery = allResultsQuery.Skip(paginationRequest.PageSize * (paginationRequest.PageNumber - 1)).Take(paginationRequest.PageSize);
+            return new PaginationResponse<TEntity>(
+                await allResultsQuery.CountAsync(),
+                await pagedResultsQuery.ToListAsync()
+            );
+        }
 
         public virtual async Task<TEntity> GetTrackedAsync(Guid id, TQueryModel queryModel) =>
             await FindEntityAsync(id, queryModel, _set.AsTracking());

--- a/CopeID.API/Services/IBaseEntityService.cs
+++ b/CopeID.API/Services/IBaseEntityService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using CopeID.API.ViewModels.Pagination;
 using CopeID.Models;
 
 namespace CopeID.API.Services
@@ -10,6 +11,7 @@ namespace CopeID.API.Services
         where TEntity : Entity
     {
         Task<List<TEntity>> GetAll();
+        Task<PaginationResponse<TEntity>> GetPaged(PaginationRequest paginationRequest);
         Task<TEntity> GetTrackedAsync(Guid id);
         Task<TEntity> GetUntrackedAsync(Guid id);
 

--- a/CopeID.API/Services/IBaseQueryableEntityService.cs
+++ b/CopeID.API/Services/IBaseQueryableEntityService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using CopeID.API.ViewModels.Pagination;
 using CopeID.Models;
 using CopeID.QueryModels;
 
@@ -12,6 +13,7 @@ namespace CopeID.API.Services
         where TQueryModel : EntityQueryModel<TEntity>
     {
         Task<List<TEntity>> GetAll(TQueryModel queryModel);
+        Task<PaginationResponse<TEntity>> GetPaged(PaginationRequest paginationRequest, TQueryModel queryModel);
         Task<TEntity> GetTrackedAsync(Guid id, TQueryModel queryModel);
         Task<TEntity> GetUntrackedAsync(Guid id, TQueryModel queryModel);
 

--- a/CopeID.API/ViewModels/Pagination/PaginationRequest.cs
+++ b/CopeID.API/ViewModels/Pagination/PaginationRequest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace CopeID.API.ViewModels.Pagination
+{
+    public class PaginationRequest
+    {
+        public int PageNumber { get; set; }
+
+        public int PageSize { get; set; }
+
+        public PaginationRequest()
+        {
+            PageNumber = -1;
+            PageSize = -1;
+        }
+
+        public PaginationRequest(int pageNumber, int pageSize)
+        {
+            PageNumber = Math.Max(1, pageNumber);
+            PageSize = pageSize;
+        }
+
+        public bool IsValid() => PageNumber > 0 && PageSize > 0;
+    }
+}

--- a/CopeID.API/ViewModels/Pagination/PaginationResponse.cs
+++ b/CopeID.API/ViewModels/Pagination/PaginationResponse.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace CopeID.API.ViewModels.Pagination
+{
+    public class PaginationResponse<T>
+    {
+        public int Count { get; set; }
+
+        public IEnumerable<T> Data { get; set; }
+
+        public PaginationResponse(int count, IEnumerable<T> data)
+        {
+            Count = count;
+            Data = data;
+        }
+    }
+}

--- a/CopeID.Core/Extensions/IQueryableExtensions.cs
+++ b/CopeID.Core/Extensions/IQueryableExtensions.cs
@@ -1,52 +1,38 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace CopeID.Core.Extensions
 {
-    // Source: https://stackoverflow.com/questions/34899933/sorting-using-property-name-as-string
     public static class IQueryableExtensions
     {
-        private static readonly Type _queryableType = typeof(Queryable);
+        public static IOrderedQueryable<T> OrderByProperty<T>(this IQueryable<T> query, string propertyName, char seperator = '.') =>
+            Queryable.OrderBy(query, CreatedNestedLambda<T>(propertyName, seperator));
 
-        private static readonly MethodInfo[] _queryableMethods = _queryableType.GetMethods().Where(x => x.GetParameters().Length == 2).ToArray();
-        private static readonly MethodInfo _orderByMethod = _queryableMethods.First(x => x.Name == "OrderBy");
-        private static readonly MethodInfo _orderByDescendingMethod = _queryableMethods.First(x => x.Name == "OrderByDescending");
-        private static readonly MethodInfo _thenByMethod = _queryableMethods.First(x => x.Name == "ThenBy");
-        private static readonly MethodInfo _thenByDescendingMethod = _queryableMethods.First(x => x.Name == "ThenByDescending");
+        public static IOrderedQueryable<T> OrderByPropertyDescending<T>(this IQueryable<T> query, string propertyName, char seperator = '.') =>
+            Queryable.OrderByDescending(query, CreatedNestedLambda<T>(propertyName, seperator));
 
-        public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> query, string propertyName)
+        public static IOrderedQueryable<T> ThenByProperty<T>(this IQueryable<T> query, string propertyName, char seperator = '.') =>
+            Queryable.ThenBy((IOrderedQueryable<T>)query, CreatedNestedLambda<T>(propertyName, seperator));
+
+        public static IOrderedQueryable<T> ThenByPropertyDescending<T>(this IQueryable<T> query, string propertyName, char seperator = '.') =>
+            Queryable.ThenByDescending((IOrderedQueryable<T>)query, CreatedNestedLambda<T>(propertyName, seperator));
+
+        // Source: https://stackoverflow.com/questions/34899933/sorting-using-property-name-as-string
+        // Source: https://stackoverflow.com/questions/29084894/how-to-use-an-expressionfunc-to-set-a-nested-property
+        private static Expression<Func<T, object>> CreatedNestedLambda<T>(string propertyName, char seperator)
         {
-            return CreateOrderedQuery(query, _orderByMethod, propertyName);
-        }
+            // Create Lambda expression (i.e. "x").
+            ParameterExpression parameterExpression = Expression.Parameter(typeof(T));
 
-        public static IOrderedQueryable<T> OrderByDescending<T>(this IQueryable<T> query, string propertyName)
-        {
-            return CreateOrderedQuery(query, _orderByDescendingMethod, propertyName);
-        }
+            // Create nested expression property (i.e. "x.Property.Nested...").
+            Expression property = propertyName.Split(seperator).Aggregate<string, Expression>(parameterExpression, (c, m) => Expression.Property(c, m));
 
-        public static IOrderedQueryable<T> ThenBy<T>(this IQueryable<T> query, string propertyName)
-        {
-            return CreateOrderedQuery(query, _thenByMethod, propertyName);
-        }
-
-        public static IOrderedQueryable<T> ThenByDescending<T>(this IQueryable<T> query, string propertyName)
-        {
-            return CreateOrderedQuery(query, _thenByDescendingMethod, propertyName);
-        }
-
-        private static IOrderedQueryable<T> CreateOrderedQuery<T>(IQueryable<T> query, MethodInfo orderMethod, string propertyName)
-        {
-            // Create Lambda expression,
-            ParameterExpression parameter = Expression.Parameter(typeof(T));
-            Expression property = Expression.Property(parameter, propertyName);
-            LambdaExpression lambda = Expression.Lambda(property, parameter);
-
-            // Convert provided method into method that uses Lambda expression above.
-            MethodInfo genericOrderMethod = orderMethod.MakeGenericMethod(typeof(T), property.Type);
-            object result = genericOrderMethod.Invoke(null, new object[] { query, lambda });
-            return (IOrderedQueryable<T>)result;
+            // Create Lambda body (i.e. "x => x.Property.Nested...").
+            Expression<Func<T, object>> lambda = Expression.Lambda<Func<T, object>>(
+                Expression.Convert(property, typeof(object)), parameterExpression
+            );
+            return lambda;
         }
     }
 }

--- a/CopeID.Core/Extensions/StringExtensions.cs
+++ b/CopeID.Core/Extensions/StringExtensions.cs
@@ -4,13 +4,29 @@ namespace CopeID.Core.Extensions
 {
     public static class StringExtensions
     {
+        public static string ToPascalCase(this string str) => str[0].ToString().ToUpper() + str.Substring(1);
+
+        public static string ToPascalCase(this string str, char seperator) => string.Join(seperator, str.Split(seperator).ToPascalCase());
+
         public static string[] ToPascalCase(this string[] strArr)
         {
             string[] result = new string[strArr.Length];
             for (int i = 0; i < strArr.Length; i++)
             {
                 if (strArr[i] == null) continue;
-                result[i] = strArr[i][0].ToString().ToUpper() + strArr[i].Substring(1);
+                result[i] = strArr[i].ToPascalCase();
+            }
+
+            return Array.FindAll(result, s => s != null) ?? Array.Empty<string>();
+        }
+
+        public static string[] ToPascalCase(this string[] strArr, char seperator)
+        {
+            string[] result = new string[strArr.Length];
+            for (int i = 0; i < strArr.Length; i++)
+            {
+                if (strArr[i] == null) continue;
+                result[i] = strArr[i].ToPascalCase(seperator);
             }
 
             return Array.FindAll(result, s => s != null) ?? Array.Empty<string>();

--- a/CopeID.Core/Extensions/TypeExtensions.cs
+++ b/CopeID.Core/Extensions/TypeExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+
+namespace CopeID.Core.Extensions
+{
+    public static class TypeExtensions
+    {
+        public static PropertyInfo GetPropertyRecursive(this Type type, string propertyName, char seperator = '.')
+        {
+            string[] split = propertyName.Split(seperator);
+            PropertyInfo result = type.GetProperty(split[0]);
+            if (result != null && split.Length > 1)
+            {
+                result = GetPropertyRecursive(
+                    result.PropertyType,
+                    string.Join(seperator, new ArraySegment<string>(split, 1, split.Length - 1))
+                );
+            }
+            return result;
+        }
+    }
+}

--- a/CopeID.QueryModels/EntityQueryModel.cs
+++ b/CopeID.QueryModels/EntityQueryModel.cs
@@ -54,7 +54,7 @@ namespace CopeID.QueryModels
         {
             if (Include != null)
             {
-                string[] includeProperties = FindValidProperties(Include.ToPascalCase());
+                string[] includeProperties = FindValidProperties(Include.ToPascalCase('.'));
                 foreach (string prop in includeProperties) query = query.Include(prop);
             }
 
@@ -66,31 +66,31 @@ namespace CopeID.QueryModels
             if (OrderBy != null || OrderByDescending != null)
             {
                 // Order query ascendingly.
-                string[] ascendingProperties = FindValidProperties(OrderBy?.ToPascalCase());
+                string[] ascendingProperties = FindValidProperties(OrderBy?.ToPascalCase('.'));
                 for (int i = 0; i < ascendingProperties.Length; i++)
                 {
                     string prop = ascendingProperties[i];
                     if (i == 0)
                     {
-                        query = query.OrderBy(prop);
+                        query = query.OrderByProperty(prop, '.');
                         continue;
                     }
 
-                    query = query.ThenBy(prop);
+                    query = query.ThenByProperty(prop, '.');
                 }
 
                 // Order query descendingly.
-                string[] descendingProperties = FindValidProperties(OrderByDescending?.ToPascalCase());
+                string[] descendingProperties = FindValidProperties(OrderByDescending?.ToPascalCase('.'));
                 for (int i = 0; i < descendingProperties.Length; i++)
                 {
                     string prop = descendingProperties[i];
                     if (i == 0 && ascendingProperties.Length == 0)
                     {
-                        query = query.OrderByDescending(prop);
+                        query = query.OrderByPropertyDescending(prop, '.');
                         continue;
                     }
 
-                    query = query.ThenByDescending(prop);
+                    query = query.ThenByPropertyDescending(prop, '.');
                 }
             }
 
@@ -100,6 +100,8 @@ namespace CopeID.QueryModels
         protected abstract IQueryable<TEntity> GetCustomQuery(IQueryable<TEntity> query);
 
         protected string[] FindValidProperties(string[] properties) =>
-            properties?.Where(x => _entityProperties.Any(p => p.Name == x)).ToArray() ?? new string[0];
+            properties?.Where(x =>
+                _entityProperties.Any(p => p.Name == x) || _entityType.GetPropertyRecursive(x) != null
+            ).ToArray() ?? Array.Empty<string>();
     }
 }


### PR DESCRIPTION
## Changes

- Created `PaginationRequest` and `PaginationResponse` models
- Added pagination models that are grabbed from the query to all applicable controller endpoints
- Adjusted `BaseEntityService` and `BaseQueryableEntityService` to page data as needed
- Improved `IQueryableExtensions` to allow ordering of nested properties with a string name and a separator
- Adjusted `StringExtensions` to support strings with a separator
- Created `TypeExtensions` to recursively find a property of any type

Closes #21 